### PR TITLE
Added an option to open the SynthDet scene to the SynthDet menu

### DIFF
--- a/SynthDet/Assets/Scripts/Editor/MenuItems.cs
+++ b/SynthDet/Assets/Scripts/Editor/MenuItems.cs
@@ -25,32 +25,6 @@ namespace SynthDet
                 Debug.LogError("Could not open the SynthDet Scene. Make sure the file Assets/Scenes/SynthDet.unity exists and is a valid Scene.");
                 Debug.LogException(e);
             }
-        }
-        
-        [MenuItem("SynthDet/Recreate Default SynthDet Scenario")]
-        static void CreateDefaultScenario()
-        {
-            var scenarioObj = new GameObject("Scenario");
-
-            var scenario = scenarioObj.AddComponent<FixedLengthScenario>();
-            scenario.constants.totalIterations = 1000;
-
-            scenario.AddRandomizer(new BackgroundObjectPlacementRandomizer());
-            scenario.AddRandomizer(new ForegroundObjectPlacementRandomizer());
-            scenario.AddRandomizer(new ForegroundOccluderPlacementRandomizer());
-            scenario.AddRandomizer(new ForegroundOccluderScaleRandomizer());
-            scenario.AddRandomizer(new ForegroundScaleRandomizer());
-            scenario.AddRandomizer(new TextureRandomizer());
-            scenario.AddRandomizer(new HueOffsetRandomizer());
-            scenario.AddRandomizer(new RotationRandomizer());
-            scenario.AddRandomizer(new UnifiedRotationRandomizer());
-            scenario.AddRandomizer(new LightRandomizer());
-            scenario.AddRandomizer(new CameraRandomizer());
-            scenario.AddRandomizer(new ForegroundObjectMetricReporter());
-            scenario.AddRandomizer(new LightingInfoMetricReporter());
-            scenario.AddRandomizer(new CameraPostProcessingMetricReporter());
-
-            Selection.activeGameObject = scenarioObj;
-        }
+        }               
     }
 }

--- a/SynthDet/Assets/Scripts/Editor/MenuItems.cs
+++ b/SynthDet/Assets/Scripts/Editor/MenuItems.cs
@@ -1,8 +1,11 @@
-﻿using SynthDet.Randomizers;
+﻿using System;
+using SynthDet.Randomizers;
 using UnityEditor;
+using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers;
 using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.SceneManagement;
 using BackgroundObjectPlacementRandomizer = SynthDet.Randomizers.BackgroundObjectPlacementRandomizer;
 using ForegroundObjectPlacementRandomizer = SynthDet.Randomizers.ForegroundObjectPlacementRandomizer;
 
@@ -10,14 +13,28 @@ namespace SynthDet
 {
     public static class MenuItems
     {
-        [MenuItem("SynthDet/Create Default Scenario")]
+        [MenuItem("SynthDet/Open SynthDet Scene")]
+        static void OpenSynthDetScene()
+        {
+            try
+            {
+                EditorSceneManager.OpenScene("Assets/Scenes/SynthDet.unity");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError("Could not open the SynthDet Scene. Make sure the file Assets/Scenes/SynthDet.unity exists and is a valid Scene.");
+                Debug.LogException(e);
+            }
+        }
+        
+        [MenuItem("SynthDet/Recreate Default SynthDet Scenario")]
         static void CreateDefaultScenario()
         {
             var scenarioObj = new GameObject("Scenario");
 
             var scenario = scenarioObj.AddComponent<FixedLengthScenario>();
             scenario.constants.totalIterations = 1000;
-            
+
             scenario.AddRandomizer(new BackgroundObjectPlacementRandomizer());
             scenario.AddRandomizer(new ForegroundObjectPlacementRandomizer());
             scenario.AddRandomizer(new ForegroundOccluderPlacementRandomizer());

--- a/SynthDet/Assets/Scripts/Editor/MenuItems.cs
+++ b/SynthDet/Assets/Scripts/Editor/MenuItems.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using SynthDet.Randomizers;
 using UnityEditor;
 using UnityEditor.SceneManagement;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers;
-using UnityEngine.Perception.Randomization.Scenarios;
-using UnityEngine.SceneManagement;
-using BackgroundObjectPlacementRandomizer = SynthDet.Randomizers.BackgroundObjectPlacementRandomizer;
-using ForegroundObjectPlacementRandomizer = SynthDet.Randomizers.ForegroundObjectPlacementRandomizer;
 
 namespace SynthDet
 {


### PR DESCRIPTION
Based on user feedback, the menu option we currently have for creating the synthdet scenario can be a bit confusing if that menu is the first thing users go to. It is meant as a recovery tool not a place to start using the project. Following discussions with Steven Leal who originally created this option, we decided to remove it.

I added another option to the menu to open the SynthDet scene, this will hopefully rectify the issue and inform the user that a SynthDet scene exists.